### PR TITLE
Bump to `pantry-0.6.0`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for mega-sdist
 
+## 0.4.3.0
+
+* Support `pantry` 0.6.0
+
 ## 0.4.2.1
 
 * Support `aeson` 2

--- a/mega-sdist.hs
+++ b/mega-sdist.hs
@@ -96,7 +96,7 @@ main = do
       runRIO lf $
       withPantryConfig
         root
-        defaultHackageSecurityConfig
+        defaultPackageIndexConfig
         HpackBundled
         8
         defaultCasaRepoPrefix

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:        mega-sdist
-version:     0.4.2.1
+version:     0.4.3.0
 synopsis:    Handles uploading to Hackage from mega repos
 description: Please see the description on Github at <https://github.com/snoyberg/mega-sdist#readme>
 category:    Distribution
@@ -16,7 +16,7 @@ dependencies:
 - base >=4 && <5
 - bytestring
 - optparse-simple
-- pantry >= 0.4
+- pantry >= 0.6
 - path
 - path-io
 - rio

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,4 @@
-resolver: lts-16.0
+resolver: lts-18.28
+
+extra-deps:
+- pantry-0.6.0@sha256:c87056df8151441911bece5c09d11738110284dc1eacb292686aa33c4308c8c2,4099


### PR DESCRIPTION
Also bumps (conservatively) `stack.yaml` to `lts-18.28` (GHC 8.10.7).

Tested by building on Windows 11.

This pull request is draft until `pantry-0.6.0` is released on Hackage.